### PR TITLE
Remove name_prefix variable where alarm can be identified without name_prefix

### DIFF
--- a/modules/alb/README.adoc
+++ b/modules/alb/README.adoc
@@ -16,7 +16,7 @@ Place this module in your application repository
 module "alb_alarms" {
   source = "github.com/nsbno/terraform-aws-alarms//modules/alb?ref=x.y.z"
 
-  name_prefix = "my-application"
+  application_name = "my-application"
   target_group_arn_suffix = "target-group/1234"
   load_balancer_arn_suffix = "loadbalancer/1234"
 

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -10,8 +10,8 @@ terraform {
 }
 
 resource "aws_cloudwatch_metric_alarm" "service_health" {
-  alarm_name        = "${var.name_prefix}-unhealthy"
-  alarm_description = "${var.name_prefix} has ${var.healthy_host_threshold} or less healthy hosts"
+  alarm_name        = "${var.application_name}-unhealthy"
+  alarm_description = "${var.application_name} has ${var.healthy_host_threshold} or less healthy hosts"
 
   metric_name = "HealthyHostCount"
   namespace   = "AWS/ApplicationELB"

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -1,5 +1,5 @@
-variable "name_prefix" {
-  description = "Prefix to apply to the alarm names"
+variable "application_name" {
+  description = "Name of the ECS service. Name is prefixed in the alarm names"
   type        = string
 }
 

--- a/modules/api-gateway/README.adoc
+++ b/modules/api-gateway/README.adoc
@@ -16,7 +16,6 @@ Place this module in your application repository
 module "api_gateway_alarms" {
   source = "github.com/nsbno/terraform-aws-alarms//modules/api-gateway?ref=x.y.z"
 
-  name_prefix = "my-application"
   api_name = "cat-api"
 
   alarm_sns_topic_arns = [data.aws_sns_topic.degraded.arn]

--- a/modules/api-gateway/main.tf
+++ b/modules/api-gateway/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_latency" {
-  alarm_name        = "${var.name_prefix}-${var.api_name}-latency"
+  alarm_name        = "${var.api_name}-latency"
   alarm_description = "${var.api_name} latency is above configured treshold"
 
   metric_name = "IntegrationLatency"
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "high_latency" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "num_errors_service" {
-  alarm_name        = "${var.name_prefix}-${var.api_name}-5xx-errors"
+  alarm_name        = "${var.api_name}-5xx-errors"
   alarm_description = "${var.api_name} has crossed the 5xx error treshold"
 
   metric_name = "5XXError"

--- a/modules/api-gateway/variables.tf
+++ b/modules/api-gateway/variables.tf
@@ -1,8 +1,3 @@
-variable "name_prefix" {
-  description = "Prefix to apply to the alarm names"
-  type        = string
-}
-
 variable "api_name" {
   description = "The name of the API in API Gateway"
   type        = string

--- a/modules/ecs-service/README.adoc
+++ b/modules/ecs-service/README.adoc
@@ -16,7 +16,6 @@ Place this module in your application repository
 module "ecs_service_alarms" {
   source = "github.com/nsbno/terraform-aws-alarms//modules/ecs-service?ref=x.y.z"
 
-  name_prefix = "my-application"
   ecs_cluster_name = data.aws_ecs_cluster.this.name
   ecs_service_name = data.aws_ecs_service.this.name
 

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {
-  alarm_name        = "${var.name_prefix}-${var.ecs_service_name}-cpu"
+  alarm_name        = "${var.ecs_service_name}-cpu"
   alarm_description = "${var.ecs_service_name} has crossed the CPU usage treshold"
 
   metric_name = "CPUUtilization"
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "high_cpu_utilization" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_memory_utilization" {
-  alarm_name        = "${var.name_prefix}-${var.ecs_service_name}-memory"
+  alarm_name        = "${var.ecs_service_name}-memory"
   alarm_description = "${var.ecs_service_name} has crossed the memory usage treshold"
 
   metric_name = "MemoryUtilization"

--- a/modules/ecs-service/variables.tf
+++ b/modules/ecs-service/variables.tf
@@ -1,8 +1,3 @@
-variable "name_prefix" {
-  description = "Prefix to apply to the alarm names"
-  type        = string
-}
-
 variable "ecs_cluster_name" {
   description = "The name of the ECS Cluster"
   type        = string

--- a/modules/lambda/README.adoc
+++ b/modules/lambda/README.adoc
@@ -16,7 +16,6 @@ Place this module in your application repository
 module "lambda_error_alarm" {
   source = "github.com/nsbno/terraform-aws-alarms//modules/lambda?ref=x.y.z"
 
-  name_prefix      = "my-application"
   lambda_name      = data.aws_lambda_function.this.function_name
 
   alarm_sns_topic_arns = [data.aws_sns_topic.lambda_error.arn]

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
-  alarm_name        = "${var.name_prefix}-${var.lambda_name}-error"
+  alarm_name        = "${var.lambda_name}-error"
   alarm_description = "${var.lambda_name} has had errors above configured threshold"
 
   metric_name = "Errors"

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -1,8 +1,3 @@
-variable "name_prefix" {
-  description = "Prefix to apply to the alarm names"
-  type        = string
-}
-
 variable "lambda_name" {
   description = "The name of the Lambda"
   type        = string


### PR DESCRIPTION
Fjerner `name_prefix` fra `variables.tf` der det ikke gjør annet enn å prefikse alarm med `trafficcontrol-` eller lignende. Renamer det i ALB-modulen siden name_prefix/application_name brukes for å prefikse alarmen med f.eks. service-navnet.