### PR TITLE
Use DBClusterIdentifier over DBInstanceIdentifier

### DIFF
--- a/modules/rds_overspent_instance_credits/README.adoc
+++ b/modules/rds_overspent_instance_credits/README.adoc
@@ -16,7 +16,7 @@ Place this module in your application repository
 module "rds_overspent_instance_credits" {
   source = "github.com/nsbno/terraform-aws-alarms//modules/rds_overspent_instance_credits?ref=x.y.z"
 
-  aurora_db_instance_name = your_db_instance_name
+  aurora_db_cluster_name = your_cluster_name
   alarm_sns_topic_arns = [data.aws_sns_topic.degraded.arn]
 }
 ----

--- a/modules/rds_overspent_instance_credits/main.tf
+++ b/modules/rds_overspent_instance_credits/main.tf
@@ -10,14 +10,14 @@ terraform {
 }
 
 resource "aws_cloudwatch_metric_alarm" "this" {
-  alarm_name        = "${var.aurora_db_instance_name}-aurora-cpu-surplus-credits-charged"
-  alarm_description = "${var.aurora_db_instance_name} has incurred charges for overspent CPU credits."
+  alarm_name        = "${var.aurora_db_cluster_identifier}-aurora-cpu-surplus-credits-charged"
+  alarm_description = "${var.aurora_db_cluster_identifier} has incurred charges for overspent CPU credits."
 
   metric_name = "CPUCreditSurplusCreditsCharged"
   namespace   = "AWS/RDS"
 
   dimensions = {
-    DBInstanceIdentifier = var.aurora_db_instance_name
+    DBClusterIdentifier = var.aurora_db_cluster_identifier
   }
 
   statistic           = "Sum"

--- a/modules/rds_overspent_instance_credits/variables.tf
+++ b/modules/rds_overspent_instance_credits/variables.tf
@@ -1,4 +1,4 @@
-variable "aurora_db_instance_name" {
+variable "aurora_db_cluster_identifier" {
   description = "The name of the Aurora DB Instance"
   type        = string
 }

--- a/modules/rds_overspent_instance_credits/variables.tf
+++ b/modules/rds_overspent_instance_credits/variables.tf
@@ -1,5 +1,5 @@
 variable "aurora_db_cluster_identifier" {
-  description = "The name of the Aurora DB Instance"
+  description = "The name of the Aurora Cluster"
   type        = string
 }
 


### PR DESCRIPTION
Etter vi forsøkte å bruke alarmen i en tjeneste som bruker en RDS-modul ser vi at vi ikke får eksponert DBInstanceIdentifier. Derimot har vi tilgang til DBClusterIdentifier som også er mer praktisk å bruke for de som har flere instances i et cluster. Skriver om alarmen til å bruke DBClusterIdentifier,