### PR TITLE
Fix faulty default variables

### DIFF
--- a/modules/cloudwatch_log_level/variables.tf
+++ b/modules/cloudwatch_log_level/variables.tf
@@ -55,5 +55,5 @@ variable "treat_missing_data" {
 variable "period" {
   description = "Period in seconds to check for the applied statistic"
   type        = number
-  default     = 60
+  default     = 120
 }

--- a/modules/cloudwatch_log_level/variables.tf
+++ b/modules/cloudwatch_log_level/variables.tf
@@ -48,12 +48,12 @@ variable "evaluation_periods" {
 variable "treat_missing_data" {
   description = "How this alarm is to handle missing data points"
   type        = string
-  default     = "notBreached"
+  default     = "notBreaching"
 }
 
 
 variable "period" {
   description = "Period in seconds to check for the applied statistic"
   type        = number
-  default     = 90
+  default     = 60
 }


### PR DESCRIPTION
Fikser et par default-verdier som fører til feil når man bruker modulen.
Feilmeldinger:
`Error: expected treat_missing_data to be one of ["breaching" "ignore" "missing" "notBreaching"], got notBreached`
`Error: expected period to be divisible by 60, got: 90`